### PR TITLE
Fix #81: Remove code that sets genre to None when description is prov…

### DIFF
--- a/tools/gradio/app.py
+++ b/tools/gradio/app.py
@@ -94,8 +94,6 @@ def generate_song(lyric, description=None, prompt_audio=None, genre=None, cfg_co
         genre = None
         description = None
     elif description is not None and description != "":
-        genre = None
-
     progress(0.0, "Start Generation")
     start = time.time()
     


### PR DESCRIPTION
…ided  When a user provides a text description for the song, the genre parameter  was being set to None, effectively ignoring the user's genre selection. This fix preserves the genre parameter when a description is provided. Closes #81